### PR TITLE
Set HDOP on Geofence point

### DIFF
--- a/src/tracker_location.cpp
+++ b/src/tracker_location.cpp
@@ -1023,6 +1023,7 @@ void TrackerLocation::loop() {
         PointData geofence_point;
         geofence_point.lat = cur_loc.latitude;
         geofence_point.lon = cur_loc.longitude;
+        geofence_point.hdop = cur_loc.horizontalDop;
 
         _geofence.UpdateGeofencePoint(geofence_point);
         _geofence.loop();


### PR DESCRIPTION
While trying to test geofences for our application I found that the geofences wouldn't trigger despite having GNSS lock. Adding some trace logging to `Geofence.loop()`'s HDOP comparison uncovered this:
```
0000141540 [app] INFO: Geofence: HDOP 18083403066314462439112861421784914595140374364337165416066633957376.000000 greater than max HDOP 7.500000
```

Setting the HDOP on the Geofence point before calling `Geofence.loop()` seems to have resolved the issue.