### PR TITLE
Add compile CI workflow

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -4,6 +4,9 @@ on: [push]
 
 jobs:
   compile:
+    strategy:
+      matrix:
+        device-os-version: [ '4.0.2', '5.3.0' ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -16,6 +19,7 @@ jobs:
         uses: particle-iot/compile-action@main
         with:
           particle-platform-name: 'tracker'
+          device-os-version: '${{ matrix.device-os-version }}'
           sources-folder: '.'
 
       - name: Upload artifact

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,25 @@
+name: Compile
+
+on: [push]
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Compile application
+        id: compile
+        uses: particle-iot/compile-action@main
+        with:
+          particle-platform-name: 'tracker'
+          sources-folder: '.'
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: tracker-firmware
+          path: ${{ steps.compile.outputs.artifact-path }}

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -25,5 +25,5 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: tracker-firmware
+          name: tracker-firmware-deviceos-${{ matrix.device-os-version }}
           path: ${{ steps.compile.outputs.artifact-path }}


### PR DESCRIPTION
This adds a CI job to build the firmware against Device OS 4.0.2 and 5.3.0 when a commit is pushed to GitHub.

The CI jobs are visible in the [Actions tab](https://github.com/particle-iot/tracker-edge/actions)

Related story: https://app.shortcut.com/particle/story/116912

Couple of notes:
 * there isn't a stable tag for `particle-iot/compile-action` yet. Soon we'll switch to `v1` instead of `main`
 * I'll investigate some better support for variable device os versions in the `compile-action` (example: semantic version ranges, e.g. `^5.3.0` or `4.*` )