### PR TITLE
Reduce gnss battery current

### DIFF
--- a/src/tracker.h
+++ b/src/tracker.h
@@ -314,11 +314,18 @@ class Tracker {
         int stop();
 
         /**
-         * @brief Prepare tracker IO and peripherals for shutdown
+         * @brief Prepare tracker IO and peripherals for low power
          *
          * @retval SYSTEM_ERROR_NONE
          */
         int end();
+
+        /**
+         * @brief Prepare tracker IO and peripherals for shutdown
+         *
+         * @retval SYSTEM_ERROR_NONE
+         */
+        int shutdown();
 
         /**
          * @brief Prepare tracker for reset and issue
@@ -387,6 +394,12 @@ class Tracker {
          * @param enable Enable IO/CAN power when true
          */
         void enableIoCanPower(bool enable);
+
+        /**
+         * @brief Force the GNSS module into low power state
+         *
+         */
+        void forceShutdownGnss();
 
         /**
          * @brief Indicates whether device can accept commands through USB interface


### PR DESCRIPTION
### Problem
The GNSS battery is used to store ephemeris data for the UBLOX M8U module between sleep cycles or basically when the module is powered off.  We need the battery current to be zero when we enter shipping mode and the current shutdown procedure doesn't allow that.

### Solution
Add additional IO reset/power sequence to force the UBLOX M8U module into a low power state and not draw current from the battery input.