### PR TITLE
Fixes USB ctrl_request_custom_handler return value

### DIFF
--- a/src/tracker.cpp
+++ b/src/tracker.cpp
@@ -30,7 +30,7 @@ void ctrl_request_custom_handler(ctrl_request* req)
     if (Tracker::instance().isUsbCommandEnabled())
     {
         String command(req->request_data, req->request_size);
-        if (CloudService::instance().dispatchCommand(command))
+        if (CloudService::instance().dispatchCommand(command) == 0)
         {
             result = SYSTEM_ERROR_NONE;
         }


### PR DESCRIPTION
# Problem

- Sending USB control requests with the Particle CLI would return INVALID_ARGUMENT when valid commands were sent, and no error when invalid commands were sent.  Essentially it was inverted.

# Solution

- Fix the return value expected from `CloudService::instance().dispatchCommand(command)`
- Now results in proper return values
```
$ particle usb send-request '{"cmd":"get_loc"}' <device_id>
Device <device_id>:
Command was successfully sent to device <device_id>.

$ particle usb send-request '{"cmd":"bad_command"}' <device_id>
Device <device_id>:
Error sending request to device <device_id>: INVALID_ARGUMENT
```